### PR TITLE
Updating ItemHandler.cs to fix bug with slot 0

### DIFF
--- a/disc_inventoryhud_server/Inventory/ItemHandler.cs
+++ b/disc_inventoryhud_server/Inventory/ItemHandler.cs
@@ -137,7 +137,7 @@ namespace disc_inventoryhud_server.Inventory
 
         private int FindFreeSlot(Dictionary<int, InventorySlot> inv)
         {
-            for (int i = 1; i < inv.Count(); i++)
+            for (int i = 1; i <= inv.Count(); i++)
             {
                 if (!inv.ContainsKey(i)) return i;
             }

--- a/disc_inventoryhud_server/Inventory/ItemHandler.cs
+++ b/disc_inventoryhud_server/Inventory/ItemHandler.cs
@@ -137,7 +137,7 @@ namespace disc_inventoryhud_server.Inventory
 
         private int FindFreeSlot(Dictionary<int, InventorySlot> inv)
         {
-            for (int i = 0; i < inv.Count(); i++)
+            for (int i = 1; i < inv.Count(); i++)
             {
                 if (!inv.ContainsKey(i)) return i;
             }


### PR DESCRIPTION
Slot 0 does not exist within the interface, inventory is slot 1 through 24. Iterating through slots should start at 1 in the FindFreeSlot function.